### PR TITLE
GEN-3947: allow the GCS image host

### DIFF
--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -7,12 +7,22 @@ import nextConfig from './next.config';
 // runtime only — a build and the whole test suite stay green while every asset
 // image 400s in production.
 describe('next.config images', () => {
-  const hostnames = (nextConfig.images?.remotePatterns ?? []).map(pattern =>
-    typeof pattern === 'string' ? pattern : pattern.hostname
+  const patterns = (nextConfig.images?.remotePatterns ?? []).map(pattern =>
+    typeof pattern === 'string' ? { hostname: pattern } : pattern
   );
+  const hostnames = patterns.map(pattern => pattern.hostname);
 
   it('allows the GCS asset host', () => {
     expect(hostnames).toContain('storage.googleapis.com');
+  });
+
+  // Without a path, /_next/image would happily optimize any public bucket on
+  // GCS on someone else's behalf.
+  it('pins the GCS host to our buckets', () => {
+    const gcs = patterns.find(
+      pattern => pattern.hostname === 'storage.googleapis.com'
+    );
+    expect(gcs?.pathname).toBe('/wukong-*/**');
   });
 
   it('still allows the S3 asset host until the production cutover is done', () => {

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,21 @@
+// The real plugin uses createRequire, which jest's module runtime cannot load.
+jest.mock('next-intl/plugin', () => () => (config: unknown) => config);
+
+import nextConfig from './next.config';
+
+// next/image rejects any host that is not whitelisted here, and it fails at
+// runtime only — a build and the whole test suite stay green while every asset
+// image 400s in production.
+describe('next.config images', () => {
+  const hostnames = (nextConfig.images?.remotePatterns ?? []).map(pattern =>
+    typeof pattern === 'string' ? pattern : pattern.hostname
+  );
+
+  it('allows the GCS asset host', () => {
+    expect(hostnames).toContain('storage.googleapis.com');
+  });
+
+  it('still allows the S3 asset host until the production cutover is done', () => {
+    expect(hostnames).toContain('*.s3.ap-southeast-3.amazonaws.com');
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,11 +24,13 @@ const nextConfig: NextConfig = {
         pathname: '/**',
       },
       // GCS (GEN-3947). Assets arrive as V4 signed URLs, so the query string
-      // carries a signature that changes on every API response.
+      // carries a signature that changes on every API response. The path is
+      // pinned to our buckets: the host alone would turn /_next/image into an
+      // optimizer for every public bucket on GCS.
       {
         protocol: 'https',
         hostname: 'storage.googleapis.com',
-        pathname: '/**',
+        pathname: '/wukong-*/**',
       },
     ],
     formats: ['image/webp', 'image/avif'],

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,11 +23,21 @@ const nextConfig: NextConfig = {
         hostname: '*.s3.ap-southeast-3.amazonaws.com',
         pathname: '/**',
       },
+      // GCS (GEN-3947). Assets arrive as V4 signed URLs, so the query string
+      // carries a signature that changes on every API response.
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
+        pathname: '/**',
+      },
     ],
     formats: ['image/webp', 'image/avif'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1600, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-    minimumCacheTTL: 2592000,
+    // Matches the signed URL lifetime: a new signature is a new cache key, so
+    // entries are never hit twice and a 30-day TTL only grows the image cache
+    // on disk. Raise this again once assets get permanent URLs.
+    minimumCacheTTL: 900,
   },
 
   // Security headers
@@ -62,7 +72,6 @@ const nextConfig: NextConfig = {
 
   // Compression and optimization
   output: 'standalone',
-
 
   // Redirects for legacy routes (e.g. from existing emails)
   async redirects() {


### PR DESCRIPTION
### **User description**
## What

- Whitelist `storage.googleapis.com` in `images.remotePatterns`. Assets now arrive as signed GCS URLs, and next/image rejects any host that is not listed — at runtime only, so nothing else catches it.
- `minimumCacheTTL` drops from 30 days to 900s. Every response carries a new signature, so a cache entry is never hit twice and the long TTL only grows the on-disk image cache. Raise it again if public assets ever get permanent URLs.
- Add a small test over the host list so it cannot quietly go missing.

S3 hosts stay until the production cutover is done.

## Heads up

`NEXT_PUBLIC_ASSET_BASE_URL` (used by `auth-layout`) builds bucket URLs directly in the client, with no API in between. Those five background images cannot be signed, so at cutover the variable has to point at the GCS bucket and those objects must be readable anonymously.

## Test

- `npm test`: 108 suites, 477 tests, all green.
- `npm run build`: clean. Only `/robots.txt` and `/sitemap.xml` prerender, so no signed URL gets baked into static HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Whitelist GCS host `storage.googleapis.com` in Next.js config.

- Reduce `minimumCacheTTL` to 900 seconds for signed URLs.

- Add unit tests for allowed image hostnames.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["next.config.ts"] -- "Defines remotePatterns & TTL" --> Tests["next.config.test.ts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.test.ts</strong><dd><code>Add tests for allowed image hostnames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.test.ts

<ul><li>Add unit tests to verify that both GCS and S3 hosts are allowed in <br><code>remotePatterns</code>.<br> <li> Mock <code>next-intl/plugin</code> to prevent Jest loading issues.</ul>


</details>


  </td>
  <td><a href="https://github.com/Liku-id/black-void/pull/279/files#diff-2c338e771eaa277c766b2ed77cb4aa35e416dc33a75e38e56af0a9ba95f9fc1c">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.ts</strong><dd><code>Whitelist GCS host and adjust cache TTL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.ts

<ul><li>Add <code>storage.googleapis.com</code> to <code>images.remotePatterns</code> to support GCS <br>signed URLs.<br> <li> Reduce <code>minimumCacheTTL</code> from 30 days (2592000s) to 15 minutes (900s) to <br>prevent disk cache bloat from unique signed URL signatures.</ul>


</details>


  </td>
  <td><a href="https://github.com/Liku-id/black-void/pull/279/files#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7b">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

